### PR TITLE
Add support for api token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New method `Art4\Wegliphant\Client::authenticate()` to set your API key for authorized API requests.
 - New class `Art4\Wegliphant\Exception\UnexpectedResponseException` that will be thrown if an error happens while processing the response.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ $client = \Art4\Wegliphant\Client::create(
 );
 ```
 
+Optionally, you can use `authenticate()` to set an API key. Some areas of the weg.li API require an API key.
+Without the API key, all requests are sent without authorization.
+You can find your API key [here](https://www.weg.li/user/edit).
+
+```php
+$client->authenticate($apiKey);
+```
+
 ### List all districts
 
 ```php

--- a/src/Client.php
+++ b/src/Client.php
@@ -21,6 +21,18 @@ final class Client
 
     private string $apiUrl = 'https://www.weg.li';
 
+    private string $apiKey = '';
+
+    private function __construct(
+        private ClientInterface $httpClient,
+        private RequestFactoryInterface $requestFactory,
+    ) {}
+
+    public function authenticate(string $apiKey): void
+    {
+        $this->apiKey = $apiKey;
+    }
+
     /**
      * List all districts using the endpoint `GET /districts.json`
      *
@@ -78,11 +90,6 @@ final class Client
         return $this->parseJsonResponseToArray($response);
     }
 
-    private function __construct(
-        private ClientInterface $httpClient,
-        private RequestFactoryInterface $requestFactory,
-    ) {}
-
     /**
      * @throws \Psr\Http\Client\ClientExceptionInterface If an error happens while processing the request.
      */
@@ -92,6 +99,10 @@ final class Client
     ): ResponseInterface {
         $request = $this->requestFactory->createRequest($method, $this->apiUrl . $path);
         $request = $request->withHeader('Accept', 'application/json');
+
+        if ($this->apiKey !== '') {
+            $request = $request->withHeader('X-API-KEY', $this->apiKey);
+        }
 
         return $this->httpClient->sendRequest($request);
     }

--- a/tests/Unit/Client/AuthenticateTest.php
+++ b/tests/Unit/Client/AuthenticateTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Art4\Wegliphant\Client;
+
+use Art4\Wegliphant\Client;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+#[CoversClass(Client::class)]
+final class AuthenticateTest extends TestCase
+{
+    public function testAuthenticateSetsCorrectHeader(): void
+    {
+        $expected = [];
+        $apiKey = 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2';
+
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->exactly(2))->method('withHeader')->willReturnMap([
+            ['Accept', 'application/json', $request],
+            ['X-API-KEY', $apiKey, $request],
+        ]);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->exactly(1))->method('createRequest')->with('GET', 'https://www.weg.li/districts.json')->willReturn($request);
+
+        $stream = $this->createConfiguredMock(
+            StreamInterface::class,
+            [
+                '__toString' => json_encode($expected),
+            ],
+        );
+
+        $response = $this->createConfiguredMock(
+            ResponseInterface::class,
+            [
+                'getStatusCode' => 200,
+                'getHeaderLine' => 'application/json',
+                'getBody' => $stream,
+            ]
+        );
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))->method('sendRequest')->willReturn($response);
+
+        $client = Client::create(
+            $httpClient,
+            $requestFactory,
+        );
+        $client->authenticate($apiKey);
+
+        $response = $client->listDistricts();
+    }
+}


### PR DESCRIPTION
Some areas of the weg.li API require an API key. This PR adds a new method to add an API key.

Required by #13.