### PR TITLE
Implement get one charge by tbnr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- New method `Art4\Wegliphant\Client::getChargeByTbnr()` to get one charge by tbnr.
 - The supported weg.li-API spec as Swagger 2.0 json format was added.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -41,8 +41,8 @@ $client = \Art4\Wegliphant\Client::create(
 );
 ```
 
-Optionally, you can use `authenticate()` to set an API key. Some areas of the weg.li API require an API key.
-Without the API key, all requests are sent without authorization.
+Optionally, you can use `authenticate()` to set an API key. Nearly all areas of the weg.li API require an API key.
+Without the API key, all requests are send without authorization.
 You can find your API key [here](https://www.weg.li/user/edit).
 
 ```php
@@ -249,6 +249,35 @@ $charges = $client->listCharges();
         'updated_at' => '2023-09-18T15:30:43.329+02:00',
     ],
     [...],
+],
+```
+
+### List one charge by tbnr
+
+```php
+$charge = $client->getChargeByTbnr('141313');
+
+// $charge contains:
+[
+    'tbnr' => '141313',
+    'description' => 'Sie parkten im absoluten Haltverbot (Zeichen 283) und behinderten +) dadurch Andere.',
+    'fine' => '40.0',
+    'bkat' => '§ 41 Abs. 1 iVm Anlage 2, § 1 Abs. 2, § 49 StVO; § 24 Abs. 1, 3 Nr. 5 StVG; 52.1 BKat; § 19 OWiG',
+    'penalty' => null,
+    'fap' => null,
+    'points' => 0,
+    'valid_from' => '2021-11-09T00:00:00.000+01:00',
+    'valid_to' => null,
+    'implementation' => 2,
+    'classification' => 5,
+    'variant_table_id' => 741017,
+    'rule_id' => 39,
+    'table_id' => null,
+    'required_refinements' => '00000000000000000000000000000000',
+    'number_required_refinements' => 1,
+    'max_fine' => '0.0',
+    'created_at' => '2023-09-18T15:30:43.329+02:00',
+    'updated_at' => '2023-09-18T15:30:43.329+02:00',
 ],
 ```
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -85,6 +85,23 @@ final class Client
     }
 
     /**
+     * Get one charge by tbnr using the endpoint `GET /api/charges/<tbnr>`
+     *
+     * @link https://www.weg.li/api
+     *
+     * @throws \Psr\Http\Client\ClientExceptionInterface If an error happens while processing the request.
+     * @throws UnexpectedResponseException If an error happens while processing the response.
+     *
+     * @return mixed[]
+     */
+    public function getChargeByTbnr(string $tbnr): array
+    {
+        $response = $this->sendJsonRequest('GET', '/api/charges/' . $tbnr);
+
+        return $this->parseJsonResponseToArray($response, 200);
+    }
+
+    /**
      * List all notices for the authorized user using the endpoint `GET /api/notices`
      *
      * @link https://www.weg.li/api-docs/index.html#operations-notice-get_notices

--- a/tests/Unit/Client/GetChargeByTbnrTest.php
+++ b/tests/Unit/Client/GetChargeByTbnrTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Art4\Wegliphant\Client;
+
+use Art4\Wegliphant\Client;
+use Art4\Wegliphant\Exception\UnexpectedResponseException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
+
+#[CoversClass(Client::class)]
+final class GetChargeByTbnrTest extends TestCase
+{
+    public function testGetChargeByTbnrReturnsArray(): void
+    {
+        $expected = [
+            'tbnr' => '141312',
+            'description' => 'Sie parkten im absoluten Haltverbot (Zeichen 283).',
+            'fine' => '25.0',
+            'bkat' => '§ 41 Abs. 1 iVm Anlage 2, § 49 StVO; § 24 Abs. 1, 3 Nr. 5 StVG; 52 BKat',
+            'penalty' => null,
+            'fap' => null,
+            'points' => 0,
+            'valid_from' => '2021-11-09T00:00:00.000+01:00',
+            'valid_to' => null,
+            'implementation' => null,
+            'classification' => 5,
+            'variant_table_id' => 741017,
+            'rule_id' => 39,
+            'table_id' => null,
+            'required_refinements' => '00000000000000000000000000000000',
+            'number_required_refinements' => 0,
+            'max_fine' => '0.0',
+            'created_at' => '2023-09-18T15:30:43.312+02:00',
+            'updated_at' => '2023-09-18T15:30:43.312+02:00',
+        ];
+
+        $apiKey = 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2';
+
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->exactly(2))->method('withHeader')->willReturnMap([
+            ['Accept', 'application/json', $request],
+            ['X-API-KEY', $apiKey, $request],
+        ]);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->exactly(1))->method('createRequest')->with('GET', 'https://www.weg.li/api/charges/141312')->willReturn($request);
+
+        $stream = $this->createConfiguredMock(
+            StreamInterface::class,
+            [
+                '__toString' => json_encode($expected),
+            ],
+        );
+
+        $response = $this->createConfiguredMock(
+            ResponseInterface::class,
+            [
+                'getStatusCode' => 200,
+                'getHeaderLine' => 'application/json',
+                'getBody' => $stream,
+            ]
+        );
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))->method('sendRequest')->willReturn($response);
+
+        $client = Client::create(
+            $httpClient,
+            $requestFactory,
+        );
+        $client->authenticate($apiKey);
+
+        $response = $client->getChargeByTbnr('141312');
+
+        $this->assertSame(
+            $expected,
+            $response,
+        );
+    }
+
+    public function testGetChargeByTbnrThrowsClientException(): void
+    {
+        $apiKey = 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2';
+
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->exactly(2))->method('withHeader')->willReturnMap([
+            ['Accept', 'application/json', $request],
+            ['X-API-KEY', $apiKey, $request],
+        ]);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->exactly(1))->method('createRequest')->with('GET', 'https://www.weg.li/api/charges/141312')->willReturn($request);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))->method('sendRequest')->willThrowException(
+            $this->createMock(ClientExceptionInterface::class),
+        );
+
+        $client = Client::create(
+            $httpClient,
+            $requestFactory,
+        );
+        $client->authenticate($apiKey);
+
+        $this->expectException(ClientExceptionInterface::class);
+        $this->expectExceptionMessage('');
+
+        $client->getChargeByTbnr('141312');
+    }
+
+    public function testGetChargeByTbnrThrowsUnexpectedResponseExceptionOnWrongStatusCode(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->exactly(1))->method('withHeader')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->exactly(1))->method('createRequest')->with('GET', 'https://www.weg.li/api/charges/000000')->willReturn($request);
+
+        $response = $this->createConfiguredMock(
+            ResponseInterface::class,
+            [
+                'getStatusCode' => 401,
+            ]
+        );
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))->method('sendRequest')->willReturn($response);
+
+        $client = Client::create(
+            $httpClient,
+            $requestFactory,
+        );
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Server replied with the status code 401, but 200 was expected.');
+
+        $client->getChargeByTbnr('000000');
+    }
+
+    public function testGetChargeByTbnrThrowsUnexpectedResponseExceptionOnWrongContentTypeHeader(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->exactly(1))->method('withHeader')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->exactly(1))->method('createRequest')->with('GET', 'https://www.weg.li/api/charges/141312')->willReturn($request);
+
+        $response = $this->createConfiguredMock(
+            ResponseInterface::class,
+            [
+                'getStatusCode' => 200,
+                'getHeaderLine' => 'text/html',
+            ]
+        );
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))->method('sendRequest')->willReturn($response);
+
+        $client = Client::create(
+            $httpClient,
+            $requestFactory,
+        );
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Server replied not with JSON content.');
+
+        $client->getChargeByTbnr('141312');
+    }
+
+    public function testGetChargeByTbnrThrowsUnexpectedResponseExceptionOnInvalidJsonBody(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->exactly(1))->method('withHeader')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->exactly(1))->method('createRequest')->with('GET', 'https://www.weg.li/api/charges/141312')->willReturn($request);
+
+        $stream = $this->createConfiguredMock(
+            StreamInterface::class,
+            [
+                '__toString' => 'invalid json',
+            ],
+        );
+
+        $response = $this->createConfiguredMock(
+            ResponseInterface::class,
+            [
+                'getStatusCode' => 200,
+                'getHeaderLine' => 'application/json',
+                'getBody' => $stream,
+            ]
+        );
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))->method('sendRequest')->willReturn($response);
+
+        $client = Client::create(
+            $httpClient,
+            $requestFactory,
+        );
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Response body contains no valid JSON: invalid json');
+
+        $client->getChargeByTbnr('141312');
+    }
+
+    public function testGetChargeByTbnrThrowsUnexpectedResponseExceptionOnJsonBodyWithoutArray(): void
+    {
+        $request = $this->createMock(RequestInterface::class);
+        $request->expects($this->exactly(1))->method('withHeader')->willReturn($request);
+
+        $requestFactory = $this->createMock(RequestFactoryInterface::class);
+        $requestFactory->expects($this->exactly(1))->method('createRequest')->with('GET', 'https://www.weg.li/api/charges/141312')->willReturn($request);
+
+        $stream = $this->createConfiguredMock(
+            StreamInterface::class,
+            [
+                '__toString' => '"this is not an array"',
+            ],
+        );
+
+        $response = $this->createConfiguredMock(
+            ResponseInterface::class,
+            [
+                'getStatusCode' => 200,
+                'getHeaderLine' => 'application/json',
+                'getBody' => $stream,
+            ]
+        );
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))->method('sendRequest')->willReturn($response);
+
+        $client = Client::create(
+            $httpClient,
+            $requestFactory,
+        );
+
+        $this->expectException(UnexpectedResponseException::class);
+        $this->expectExceptionMessage('Response JSON does not contain an array: "this is not an array"');
+
+        $client->getChargeByTbnr('141312');
+    }
+}


### PR DESCRIPTION
This PR implements the new endpoint `GET /charges/{tbnr}`.